### PR TITLE
Chore: downgrade device_info_plus

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ description: A highly customizable rich-text editor for Flutter. The AppFlowy
 
 dependencies:
   collection: "^1.18.0"
-  device_info_plus: ^12.3.0
+  device_info_plus: '>=10.0.1 <12.0.0'
   diff_match_patch: "^0.4.1"
   file_picker: ^10.2.0
   flutter:


### PR DESCRIPTION
Lowered device_info_plus constraint in appflowy_editor to resolve dependency conflict with super_native_extensions / super_clipboard.

close: #4