### PR TITLE
fix: ensure cursor position after image nodes in markdown serialization

### DIFF
--- a/lib/src/plugins/markdown/decoder/parser/markdown_image_parser.dart
+++ b/lib/src/plugins/markdown/decoder/parser/markdown_image_parser.dart
@@ -18,6 +18,7 @@ class MarkdownImageParserV2 extends CustomMarkdownParser {
     if (element.attributes['src'] != null) {
       return [
         imageNode(url: element.attributes['src']!),
+        paragraphNode(),
       ];
     }
 
@@ -33,6 +34,7 @@ class MarkdownImageParserV2 extends CustomMarkdownParser {
 
     return [
       imageNode(url: ec.attributes['src']!),
+      paragraphNode(),
     ];
   }
 }

--- a/lib/src/plugins/markdown/encoder/parser/image_node_parser.dart
+++ b/lib/src/plugins/markdown/encoder/parser/image_node_parser.dart
@@ -8,6 +8,8 @@ class ImageNodeParser extends NodeParser {
 
   @override
   String transform(Node node, DocumentMarkdownEncoder? encoder) {
-    return '![](${node.attributes[ImageBlockKeys.url]})';
+    final imageMarkdown = '![](${node.attributes[ImageBlockKeys.url]})';
+    final suffix = node.next == null ? '' : '\n';
+    return '$imageMarkdown$suffix';
   }
 }

--- a/test/plugins/markdown/decoder/image_decoder_test.dart
+++ b/test/plugins/markdown/decoder/image_decoder_test.dart
@@ -18,6 +18,9 @@ void main() async {
           'align': 'center',
         },
       });
+      // After the image, there should be an empty paragraph for the cursor to be positioned
+      expect(result.root.children[1].type, 'paragraph');
+      expect(result.root.children[1].delta?.isEmpty, true);
     });
   });
 }

--- a/test/plugins/markdown/encoder/parser/image_node_parser_test.dart
+++ b/test/plugins/markdown/encoder/parser/image_node_parser_test.dart
@@ -12,12 +12,29 @@ void main() async {
       );
 
       final result = const ImageNodeParser().transform(node, null);
-      expect(result, '![](https://appflowy.io)');
+      expect(result, '![](https://appflowy.io)\n');
     });
 
     test('ImageNodeParser id getter', () {
       const imageNodeParser = ImageNodeParser();
       expect(imageNodeParser.id, 'image');
+    });
+
+    test('parser image node with next node (no trailing newline)', () {
+      final pageNode = Node(type: 'page', children: [
+        Node(
+          type: 'image',
+          attributes: {
+            'url': 'https://appflowy.io/image.png',
+          },
+        ),
+        Node(type: 'paragraph'),
+      ]);
+
+      final imageNode = pageNode.children[0];
+      final result = const ImageNodeParser().transform(imageNode, null);
+      // When there's a next node, trailing newline should be added
+      expect(result, '![](https://appflowy.io/image.png)\n');
     });
   });
 }


### PR DESCRIPTION
- Automatically append empty paragraph after images during markdown parsing and add proper line breaks during encoding to allow cursor placement below images.

close: #14